### PR TITLE
feature : Set export type in command line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ jobs:
       python: "3.9"
       install:
         - pip install -e .[dev]  # Triggers cmake under the hood
-      script:
+        - pip install numpy==1.21.0 # Fixing Py3Dtilers dependency conflict
+      script: 
         - flake8 .
         - pytest tests
     - stage: "Markdown link checks"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ pySunlight is one repository of the Sunlight project, including :
 1. Install python 3.9.
 
    ```
-   apt-get install python3.9 python3.9-dev
+   apt-get install python3.9 python3.9-dev python3.9-venv
+   ```
+
+   or
+
+   ```
+   apt-get install python3.9-full
    ```
 
 2. [Follow the install guide of PostgreSQL / PostGIS](https://github.com/VCityTeam/UD-SV/blob/master/Install/Setup_PostgreSQL_PostGIS_Ubuntu.md).
@@ -91,6 +97,7 @@ pySunlight is one repository of the Sunlight project, including :
 
    ```
    pip install -e .
+   pip install --force-reinstall numpy==1.21.0 # This fixes py3DTilers broken numpy requirements
    ```
 
 ## For Mac OS
@@ -137,6 +144,7 @@ Additionnaly, and because py3dTilers requires it (although pySunlight doesn't),
 
    ```
    pip install -e .
+   pip install --force-reinstall numpy==1.21.0 # This fixes py3DTilers broken numpy requirements
    ```
 
 ## For Windows
@@ -175,6 +183,7 @@ Additionnaly, and because py3dTilers requires it (although pySunlight doesn't),
 
    ```
    pip install -e .
+   pip install --force-reinstall numpy==1.21.0 # This fixes py3DTilers broken numpy requirements
    ```
 
 ## Usage
@@ -196,6 +205,7 @@ Here is a full list of all options available :
 | --end-date, -e        | End date of sunlight computation                                                                                      | -e 403248                                 |
 | --with-aggregate      | Add aggregate to 3DTiles export, heavely impact performance                                                           | --with-aggregate                          |
 | --log-level, -log     | Provide logging level depending on [logging module](https://docs.python.org/3/howto/logging.html#when-to-use-logging) | -log DEBUG                                |
+| --export-format, -f| Choose export format from TILE, CSV or JSON. default=TILE | -f TILE                                |
 
 # Contributing
 
@@ -232,7 +242,7 @@ Here is the pipeline we follow for pySunlight :
 
 ```
 pySunlight (repo)
-├── datas                     # Datas use for testing
+├── datas                     # Datas used for testing
 ├── docs                      # Documentations (original charts...)
 ├── src                       # Source code
 ├── Sunlight                  # Sunlight repository as git submodule
@@ -244,6 +254,7 @@ pySunlight (repo)
 ├── README.md
 ├── pySunlight.i              # SWIG interface file to expose Sunlight in python
 ├── setup.py                  # Install python requirements
+├── pytest.ini                # Specify test environment
 ```
 
 ## License

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+# home/pytest.ini
+[pytest]
+pythonpath = .

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ requirements = (
     'py3dtilers @ git+https://github.com/VCityTeam/py3dtilers@3bf0ccd0e974a4e070de3a32c807cb78cc3fc7e9',
 
     # Display memory size TODO move in dev requirements after removing all usages in main files
-    'pympler'
+    'pympler',
+    'numpy==1.20.3'
 )
 
 dev_requirements = (

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from src.Aggregators.AggregatorController import \
     AggregatorControllerInBatchTable
 from src.Converters import SunlightToTiler, TilerToSunlight
 from src.TileWrapper import TileWrapper
-from src.Writers import JsonWriter, TileWriter, Writer
+from src.Writers import JsonWriter, TileWriter, Writer, CsvWriter
 
 
 def export_with_triangle_level(tiler: TilesetTiler, tileset: TileSet):
@@ -155,9 +155,12 @@ def produce_3DTiles_sunlight(sun_datas_list: pySunlight.SunDatasList, tiler: Til
     """
     # Merge all tiles to create one TileSet
     tileset = tiler.read_and_merge_tilesets()
-    # writer = CsvWriter()
-    # writer = JsonWriter()
-    writer = TileWriter(None, tiler)
+    if args.export_format == "CSV":
+        writer = CsvWriter()
+    elif args.export_format == "JSON":
+        writer = JsonWriter()
+    else:
+        writer = TileWriter(None, tiler)
 
     # Export a 3D Tiles containing the geometry if export does not provide geometry export
     # So we can associate a geometry with a result in vizualisation
@@ -202,6 +205,9 @@ def parse_command_line():
     # Set Logging level for the whole application
     parser.add_argument('--log-level', '-log', dest='log_level', default='WARNING', choices=logging._nameToLevel.keys(), help='Provide logging level. Ex : --log-level DEBUG, default=WARNING')
 
+    # Choosing export format
+    parser.add_argument('--export-format', '-f', dest='export_format', default='TILE', choices=['TILE', 'CSV', 'JSON'], help='Choose export format from TILE, CSV or JSON. default=TILE')
+
     return parser.parse_known_args()[0]
 
 
@@ -218,6 +224,7 @@ def main():
     tiler.parse_command_line()
 
     produce_3DTiles_sunlight(sunParser.getSunDatas(), tiler, args)
+
 
 if __name__ == '__main__':
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -83,6 +83,7 @@ def compute_3DTiles_sunlight(tileset: TileSet, sun_datas: pySunlight.SunDatas, w
 
         # Intialize containers
         results = SunlightToTiler.convert_to_feature_list_with_triangle_level(tile_wrapper.get_triangles())
+        featurelist = results.get_features()
 
         # Record ray hits accross the whole tile comparaison to get the closest intersection
         ray_hits_by_index = dict()
@@ -102,7 +103,7 @@ def compute_3DTiles_sunlight(tileset: TileSet, sun_datas: pySunlight.SunDatas, w
                 if not pySunlight.isFacingTheSun(triangle, sun_datas.direction):
                     # Associate shadow with the same triangle, because there's
                     # nothing blocking it but itself
-                    temp_feature = results.get_features()[triangle_index]
+                    temp_feature = featurelist[triangle_index]
                     SunlightToTiler.record_result_in_batch_table(temp_feature, sun_datas.dateStr, False, triangle.getId())
                     continue
 

--- a/src/main.py
+++ b/src/main.py
@@ -156,8 +156,8 @@ def produce_3DTiles_sunlight(sun_datas_list: pySunlight.SunDatasList, tiler: Til
     # Merge all tiles to create one TileSet
     tileset = tiler.read_and_merge_tilesets()
     # writer = CsvWriter()
-    writer = JsonWriter()
-    # writer = TileWriter(None, tiler)
+    # writer = JsonWriter()
+    writer = TileWriter(None, tiler)
 
     # Export a 3D Tiles containing the geometry if export does not provide geometry export
     # So we can associate a geometry with a result in vizualisation
@@ -218,7 +218,6 @@ def main():
     tiler.parse_command_line()
 
     produce_3DTiles_sunlight(sunParser.getSunDatas(), tiler, args)
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Related to issue #22 

1. I modified the readme.md to reflect the new options available in CLI.
2. Added a new option via ArgumentParser in main.py

Example : 
* --f TILE will make the program export in 3DTiles format
* --f JSON will make it export in JSON
* --f CSV will make it export in CSV